### PR TITLE
Add Bottom region block for copyright text.

### DIFF
--- a/config/install/block.block.umami_footer.yml
+++ b/config/install/block.block.umami_footer.yml
@@ -15,9 +15,9 @@ provider: null
 plugin: 'system_menu_block:footer'
 settings:
   id: 'system_menu_block:footer'
-  label: 'Footer menu'
+  label: 'Tell us what you think'
   provider: system
-  label_display: '0'
+  label_display: '1'
   level: 1
   depth: 0
 visibility: {  }

--- a/config/optional/block.block.umami_disclaimer.yml
+++ b/config/optional/block.block.umami_disclaimer.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - demo_umami_content
+  theme:
+    - umami
+id: umami_disclaimer
+theme: umami
+region: bottom
+weight: 10
+provider: null
+plugin: umami_disclaimer
+settings:
+  id: umami_disclaimer
+  label: 'Umami disclaimer'
+  provider: demo_umami_content
+  label_display: '0'
+visibility: {  }

--- a/config/optional/block.block.umami_footer_promo.yml
+++ b/config/optional/block.block.umami_footer_promo.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - demo_umami_content
+  theme:
+    - umami
+id: umami_footer_promo
+theme: umami
+region: footer
+weight: -1
+provider: null
+plugin: umami_footer_promo
+settings:
+  id: umami_footer_promo
+  label: 'Umami Footer promo'
+  provider: demo_umami_content
+  label_display: '0'
+visibility: {  }

--- a/demo_umami_content/src/Plugin/Block/UmamiDisclaimer.php
+++ b/demo_umami_content/src/Plugin/Block/UmamiDisclaimer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\demo_umami_content\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'Powered by Drupal' block.
+ *
+ * @Block(
+ *   id = "umami_disclaimer",
+ *   admin_label = @Translation("Umami disclaimer")
+ * )
+ */
+class UmamiDisclaimer extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['label_display' => FALSE];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return ['#markup' => '<span class="umami-disclaimer">' . $this->t('<strong>Umami Magazine & Umami Publications</strong> is a fictional magazine and publisher for illustrative purposes only.') . '</span><span class="umami-copyright">© 2017 ' . $this->t('Terms & Conditions') . '</span>'];
+  }
+
+}

--- a/demo_umami_content/src/Plugin/Block/UmamiFooterPromo.php
+++ b/demo_umami_content/src/Plugin/Block/UmamiFooterPromo.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\demo_umami_content\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'Promo banner' block for footer.
+ *
+ * @Block(
+ *   id = "umami_footer_promo",
+ *   admin_label = @Translation("Umami Bundle")
+ * )
+ */
+class UmamiFooterPromo extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['label_display' => FALSE];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return ['#markup' => '<h2 class="footer-promo__title">' . $this->t('Umami Food Magazine') . '</h2><p class="footer-promo__text">' . $this->t('Skills and know-how. Magazine exclusive articles, recipes and plenty of reasons to get your copy today. <a href=":findmore">Find out more</a>', [':findmore' => 'https://www.drupal.org']) . '</p>'];
+  }
+
+}


### PR DESCRIPTION
I've added the text that should be placed at the bottom region as a block in the installation profile instead of adding it as some text on the twig file. I've tried to emulate the Powered by Drupal block.