### PR TITLE
Made demo_umami_content Blocks configurable.

### DIFF
--- a/config/optional/block.block.umami_disclaimer.yml
+++ b/config/optional/block.block.umami_disclaimer.yml
@@ -16,4 +16,10 @@ settings:
   label: 'Umami disclaimer'
   provider: demo_umami_content
   label_display: '0'
+  umami_disclaimer:
+    value: '<strong>Umami Magazine & Umami Publications</strong> is a fictional magazine and publisher for illustrative purposes only.'
+    format: 'basic_html'
+  umami_copyright:
+    value: '&copy; 2017 Terms & Conditions'
+    format: 'basic_html'
 visibility: {  }

--- a/config/optional/block.block.umami_footer_promo.yml
+++ b/config/optional/block.block.umami_footer_promo.yml
@@ -16,4 +16,8 @@ settings:
   label: 'Umami Footer promo'
   provider: demo_umami_content
   label_display: '0'
+  promo_title: 'Umami Food Magazine'
+  promo_text: 'Skills and know-how. Magazine exclusive articles, recipes and plenty of reasons to get your copy today.'
+  findmore_url: 'https://www.drupal.org'
+  findmore_text: 'Find out more'
 visibility: {  }

--- a/demo_umami_content/src/Plugin/Block/UmamiDisclaimer.php
+++ b/demo_umami_content/src/Plugin/Block/UmamiDisclaimer.php
@@ -3,9 +3,10 @@
 namespace Drupal\demo_umami_content\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Provides a 'Powered by Drupal' block.
+ * Provides a 'Umami disclaimer' block.
  *
  * @Block(
  *   id = "umami_disclaimer",
@@ -18,14 +19,67 @@ class UmamiDisclaimer extends BlockBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return ['label_display' => FALSE];
+    return [
+      'label_display' => FALSE,
+      'umami_disclaimer' => [
+        'value' => '',
+        'format' => '',
+      ],
+      'umami_copyright' => [
+        'value' => '',
+        'format' => '',
+      ],
+    ] + parent::defaultConfiguration();
   }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    return ['#markup' => '<span class="umami-disclaimer">' . $this->t('<strong>Umami Magazine & Umami Publications</strong> is a fictional magazine and publisher for illustrative purposes only.') . '</span><span class="umami-copyright">© 2017 ' . $this->t('Terms & Conditions') . '</span>'];
+    $disclaimer_markup = check_markup($this->configuration['umami_disclaimer']['value'], $this->configuration['umami_disclaimer']['format']);
+    $copyright_markup = check_markup($this->configuration['umami_copyright']['value'], $this->configuration['umami_copyright']['format']);
+
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<span class="umami-disclaimer">{{ disclaimer }}</span><span class="umami-copyright">{{ copyright }}</span>',
+      '#context' => [
+        'disclaimer' => $disclaimer_markup,
+        'copyright' => $copyright_markup,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+
+    $form['umami_disclaimer'] = array(
+      '#type' => 'text_format',
+      '#title' => $this->t('Umami Disclaimer'),
+      '#default_value' => $this->configuration['umami_disclaimer']['value'],
+      '#format' => $this->configuration['umami_disclaimer']['format'],
+    );
+
+    $form['umami_copyright'] = array(
+      '#type' => 'text_format',
+      '#title' => $this->t('Umami Copyright Text'),
+      '#default_value' => $this->configuration['umami_copyright']['value'],
+      '#format' => $this->configuration['umami_copyright']['format'],
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    parent::blockSubmit($form, $form_state);
+
+    $this->configuration['umami_disclaimer'] = $form_state->getValue('umami_disclaimer');
+    $this->configuration['umami_copyright'] = $form_state->getValue('umami_copyright');
   }
 
 }

--- a/demo_umami_content/src/Plugin/Block/UmamiFooterPromo.php
+++ b/demo_umami_content/src/Plugin/Block/UmamiFooterPromo.php
@@ -3,6 +3,7 @@
 namespace Drupal\demo_umami_content\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides a 'Promo banner' block for footer.
@@ -18,14 +19,80 @@ class UmamiFooterPromo extends BlockBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return ['label_display' => FALSE];
+    return [
+      'label_display' => FALSE,
+      'promo_title' => '',
+      'promo_text' => '',
+      'findmore_url' => '',
+      'findmore_text' => '',
+    ] + parent::defaultConfiguration();
   }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    return ['#markup' => '<h2 class="footer-promo__title">' . $this->t('Umami Food Magazine') . '</h2><p class="footer-promo__text">' . $this->t('Skills and know-how. Magazine exclusive articles, recipes and plenty of reasons to get your copy today. <a href=":findmore">Find out more</a>', [':findmore' => 'https://www.drupal.org']) . '</p>'];
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<h2 class="footer-promo__title">{{ promo_title }}</h2><p class="footer-promo__text">{{ promo_text }} {% if findmore_url %} <a href="{{ findmore_url }}">{{ findmore_text }}</a> {% endif %}</p>',
+      '#context' => [
+        'promo_title' => $this->configuration['promo_title'],
+        'promo_text' => $this->configuration['promo_text'],
+        'findmore_url' => $this->configuration['findmore_url'],
+        'findmore_text' => $this->configuration['findmore_text'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+
+    $form['promo_title'] = array(
+      '#type' => 'textfield',
+      '#title' => $this->t('Promo Title'),
+      '#default_value' => $this->configuration['promo_title'],
+    );
+
+    $form['promo_text'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Promo Text'),
+      '#default_value' => $this->configuration['promo_text'],
+    );
+
+    $form['findmore'] = array(
+      '#type' => 'fieldset',
+      '#title' => $this->t('Find more'),
+    );
+
+    $form['findmore']['url'] = array(
+      '#type' => 'url',
+      '#title' => $this->t('URL'),
+      '#default_value' => $this->configuration['findmore_url'],
+      '#description' => $this->t('Enter an absolute url. Eg: https://www.drupal.org'),
+    );
+
+    $form['findmore']['text'] = array(
+      '#type' => 'textfield',
+      '#title' => $this->t('Text'),
+      '#default_value' => $this->configuration['findmore_text'],
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    parent::blockSubmit($form, $form_state);
+
+    $this->configuration['promo_title'] = $form_state->getValue('promo_title');
+    $this->configuration['promo_text'] = $form_state->getValue('promo_text');
+    $this->configuration['findmore_url'] = $form_state->getValue(['findmore', 'url']);
+    $this->configuration['findmore_text'] = $form_state->getValue(['findmore', 'text']);
   }
 
 }


### PR DESCRIPTION
Ref: https://github.com/gareth-fivemile/demo_umami/issues/7

* Added config forms to `UmamiDisclaimer.php` & `UmamiFooterPromo.php` Blocks. 
* Added Configuration in `config/optional` folder.