### PR TITLE
#9: Text format changes.

### DIFF
--- a/config/install/filter.format.basic_html.yml
+++ b/config/install/filter.format.basic_html.yml
@@ -42,3 +42,9 @@ filters:
     status: true
     weight: 11
     settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }

--- a/demo_umami_content/migrations/demo_umami_content__article.yml
+++ b/demo_umami_content/migrations/demo_umami_content__article.yml
@@ -11,7 +11,7 @@ process:
   'body/value': body
   'body/format':
     plugin: default_value
-    default_value: 'full_html'
+    default_value: 'basic_html'
   path: slug
   field_tags:
     -
@@ -41,4 +41,4 @@ migration_dependencies:
     # - demo_umami_content__article_images_url
 dependencies:
   config:
-    - filter.format.full_html.yml
+    - filter.format.basic_html.yml

--- a/demo_umami_content/migrations/demo_umami_content__pages.yml
+++ b/demo_umami_content/migrations/demo_umami_content__pages.yml
@@ -11,7 +11,7 @@ process:
   'body/value': body
   'body/format':
     plugin: default_value
-    default_value: 'full_html'
+    default_value: 'basic_html'
   path: slug
   uid:
     plugin: migration_lookup
@@ -25,4 +25,4 @@ migration_dependencies:
     - demo_umami_content__page_authors
 dependencies:
   config:
-    - filter.format.full_html.yml
+    - filter.format.basic_html.yml

--- a/demo_umami_content/migrations/demo_umami_content__recipes.yml
+++ b/demo_umami_content/migrations/demo_umami_content__recipes.yml
@@ -9,7 +9,10 @@ source:
 process:
   title: title
 #  image:
-  field_summary: summary
+  'field_summary/value': summary
+  'field_summary/format':
+    plugin: default_value
+    default_value: 'basic_html'
 #  author:
   field_preparation_time: preparation_time
   field_cooking_time: cooking_time
@@ -20,7 +23,10 @@ process:
     plugin: explode
     delimiter: ','
     source: ingredients
-  field_recipe_instruction: recipe_instruction
+  'field_recipe_instruction/value': recipe_instruction
+  'field_recipe_instruction/format':
+    plugin: default_value
+    default_value: 'basic_html'
   # @todo does this field exist already?
 #  tags:
   # @todo This field does not exist yet
@@ -66,3 +72,6 @@ migration_dependencies:
     - demo_umami_content__authors
 #    - demo_umami_content__media_images_url
 #    - demo_umami_content__images_url
+dependencies:
+  config:
+    - filter.format.basic_html.yml


### PR DESCRIPTION
REF: https://github.com/gareth-fivemile/demo_umami/issues/9

* Added 'basic_html' text format to `body`, `field_recipe_instruction` & `field_summary` fields.
* Modified migrations of 'article', 'page' & 'recpie' content types. 
* Enabled "auto convert of line breaks to `<p>` tags" in basic_html filter. 
