### PR TITLE
36: Implemented hook_requirements in demo_umami.install.

### DIFF
--- a/demo_umami.install
+++ b/demo_umami.install
@@ -17,16 +17,21 @@ function demo_umami_requirements($phase) {
   if ($phase == 'runtime') {
     $demo_umami_installed_drupal = \Drupal::state()->get('demo_umami_drupal_version');
 
-    $requirements['demo_umami_drupal_version'] = [
-      'title' => 'Demo Umami Drupal Version',
+    $requirements['experimental_profile_used'] = [
+      'title' => t('Experimental profile used'),
       'value' => \Drupal::VERSION,
-      'description' => 'Demo Umami is an experimental profile and not to be used in Production(Live) site. Drupal Upgrade is not recomended.',
+      'description' => t('Demo Umami is an experimental profile to be used for demonstration purposes only, and should not be used for a production/live site. To start building a new site, you should re-install Drupal and choose another profile, for example "Standard".'),
       'severity' => REQUIREMENT_WARNING,
     ];
 
     // Check if Drupal version has changed since demo_umami was installed.
     if ($demo_umami_installed_drupal != \Drupal::VERSION) {
-      $requirements['demo_umami_drupal_version']['severity'] = REQUIREMENT_ERROR;
+      $requirements['demo_umami_drupal_version'] = [
+        'title' => t('Demo Umami Drupal Version'),
+        'value' => \Drupal::VERSION,
+        'description' => t('Drupal has been updated since this demo was installed, which could cause issues with this site. It is recommended that you re-install the demo to evaluate the latest changes.'),
+        'severity' => REQUIREMENT_ERROR,
+      ];
     }
   }
   return $requirements;
@@ -96,6 +101,6 @@ function demo_umami_install() {
   // the profile (fields etc.).
   \Drupal::service('module_installer')->install(['demo_umami_content'], TRUE);
 
-  // Storing Drupal version on demo_umami install.
+  // Store the version of Drupal installed.
   \Drupal::state()->set('demo_umami_drupal_version', \Drupal::VERSION);
 }

--- a/demo_umami.install
+++ b/demo_umami.install
@@ -10,6 +10,29 @@ use Drupal\user\RoleInterface;
 use Drupal\shortcut\Entity\Shortcut;
 
 /**
+ * Implements hook_requirements().
+ */
+function demo_umami_requirements($phase) {
+  $requirements = [];
+  if ($phase == 'runtime') {
+    $demo_umami_installed_drupal = \Drupal::state()->get('demo_umami_drupal_version');
+
+    $requirements['demo_umami_drupal_version'] = [
+      'title' => 'Demo Umami Drupal Version',
+      'value' => \Drupal::VERSION,
+      'description' => 'Demo Umami is an experimental profile and not to be used in Production(Live) site. Drupal Upgrade is not recomended.',
+      'severity' => REQUIREMENT_WARNING,
+    ];
+
+    // Check if Drupal version has changed since demo_umami was installed.
+    if ($demo_umami_installed_drupal != \Drupal::VERSION) {
+      $requirements['demo_umami_drupal_version']['severity'] = REQUIREMENT_ERROR;
+    }
+  }
+  return $requirements;
+}
+
+/**
  * Implements hook_install().
  *
  * Perform actions to set up the site for this profile.
@@ -72,4 +95,7 @@ function demo_umami_install() {
   // in the demo_umami.info.yml file, as it requires configuration provided by
   // the profile (fields etc.).
   \Drupal::service('module_installer')->install(['demo_umami_content'], TRUE);
+
+  // Storing Drupal version on demo_umami install.
+  \Drupal::state()->set('demo_umami_drupal_version', \Drupal::VERSION);
 }

--- a/tests/src/Functional/DemoUmamiProfileTest.php
+++ b/tests/src/Functional/DemoUmamiProfileTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\Tests\demo_umami\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests demo_umami profile.
+ *
+ * @group demo_umami
+ */
+class DemoUmamiProfileTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'demo_umami';
+
+  /**
+   * Tests demo_umami profile warnings shown on Status Page.
+   */
+  public function testWarningsOnStatusPage() {
+    $account = $this->drupalCreateUser(['administer site configuration']);
+    $this->drupalLogin($account);
+
+    // Check the requirements warning for using an experimental profile.
+    $this->drupalGet('admin/reports/status');
+    $this->assertSession()->pageTextContains('Demo Umami is an experimental profile to be used for demonstration purposes only, and should not be used for a production/live site. To start building a new site, you should re-install Drupal and choose another profile, for example "Standard".');
+
+    // Check the requirements error for the version of Drupal being updated.
+    // Change the stored installed version of Drupal.
+    \Drupal::state()->set('demo_umami_drupal_version', \Drupal::VERSION . '1');
+    $this->drupalGet('admin/reports/status');
+    $this->assertSession()->pageTextContains('Drupal has been updated since this demo was installed, which could cause issues with this site. It is recommended that you re-install the demo to evaluate the latest changes.');
+
+  }
+}


### PR DESCRIPTION
Ref: #36 
This is an initial work for `hook_requirements()`. This by default shows a warning of experimental profile in status page. If drupal version is changed ERROR is shown. 
  