### PR TITLE
Fix @return description from InstallHelper::fileUnmanagedCopy().

### DIFF
--- a/demo_umami_content/src/InstallHelper.php
+++ b/demo_umami_content/src/InstallHelper.php
@@ -406,7 +406,8 @@ class InstallHelper implements ContainerInjectionInterface {
    * @param string $path
    *   Path to image.
    *
-   * @return bool|null
+   * @return string|false
+   *   The path to the new file, or FALSE in the event of an error.
    */
   protected function fileUnmanagedCopy($path) {
     $filename = basename($path);


### PR DESCRIPTION
This reuses the description from the wrapped file_unmanaged_copy(), as we directly return the output from that function.