### PR TITLE
Disabled taxonomy term RSS page.

### DIFF
--- a/config/install/views.view.taxonomy_term.yml
+++ b/config/install/views.view.taxonomy_term.yml
@@ -283,6 +283,7 @@ display:
           relationship: none
           view_mode: default
       display_extenders: {  }
+      enabled: false
     cache_metadata:
       contexts:
         - 'languages:language_interface'


### PR DESCRIPTION
I think we should disable RSS pages until we can implement them properly within the theme / design.